### PR TITLE
[daemon] give priority to last=new keys

### DIFF
--- a/daemon/src/keymapping.cpp
+++ b/daemon/src/keymapping.cpp
@@ -120,8 +120,7 @@ void keymapping::process(QByteArray inputReport)
         else if (key == 0xEC) { retKey.append(qMakePair(KEY_2, FORCE_SHIFT)); /* @ */ }
         else if (key == 0xEF) { retKey.append(qMakePair(KEY_ENTER, 0)); }
 
-        if (!retKey.empty())
-            break;
+        if (retKey.size() > 1) { retKey.removeFirst(); }
     }
 
     if (__symPressed && !retKey.empty())

--- a/daemon/src/tohkeyboard.cpp
+++ b/daemon/src/tohkeyboard.cpp
@@ -333,7 +333,11 @@ void Tohkbd::handleGpioInterrupt()
     }
     else
     {
-        keymap->process(tca8424->readInputReport());
+	QByteArray r = tca8424->readInputReport();
+        if (!r.isEmpty()) {
+            presenceTimer->start();
+            keymap->process(r);
+        }
     }
 }
 
@@ -342,8 +346,6 @@ void Tohkbd::handleGpioInterrupt()
 void Tohkbd::handleKeyPressed(QList< QPair<int, int> > keyCode)
 {
     bool processAllKeys = true;
-
-    presenceTimer->start();
 
     if (!displayIsOn && !slideEventEmitted)
     {


### PR DESCRIPTION
instead of making unwanted repeat of old keys

I have a feeling that this is what people are confused by about repeat.
On a normal keyboard when you press a second key you get the second key once, not a repeat of the 1st key. This also stops the autorepeat from starting while you're wondering why the 2nd key you're actually wanting to press didnt show up.
In my usage this is not very noticeable change (I do feel it is better, but .. very slightly),
i dont type this fast, but i think it'd be an improvement to others.

EDIT: Oh yeah this doesnt notice new keys if you do eg, a-down, b-down, a-up, c-down because then c will use the slot before b...
A proper solution will need a state tracker (memory of last report).
