### PR TITLE
add sticky shift and lock mode for all modifiers. 

### DIFF
--- a/daemon/daemon.pro
+++ b/daemon/daemon.pro
@@ -35,7 +35,8 @@ SOURCES += \
     src/tca8424driver.cpp \
     src/keymapping.cpp \
     src/adaptor.cpp \
-    src/eepromdriver.cpp
+    src/eepromdriver.cpp \
+    src/modifierhandler.cpp
 
 HEADERS += \
     src/toh.h \
@@ -48,7 +49,8 @@ HEADERS += \
     src/adaptor.h \
     src/defaultSettings.h \
     src/eepromdriver.h \
-    src/keymapping_lut.h
+    src/keymapping_lut.h \
+    src/modifierhandler.h
 
 OTHER_FILES += \
     config/$${TARGET}.service \

--- a/daemon/src/defaultSettings.h
+++ b/daemon/src/defaultSettings.h
@@ -20,9 +20,15 @@
 #define KEYREPEAT_DELAY 250
 #define KEYREPEAT_RATE 25
 
+#define STICKY_SHIFT_ENABLED false
 #define STICKY_CTRL_ENABLED true
 #define STICKY_ALT_ENABLED false
 #define STICKY_SYM_ENABLED false
+#define LOCKING_SHIFT_ENABLED false
+#define LOCKING_CTRL_ENABLED false
+#define LOCKING_ALT_ENABLED false
+#define LOCKING_SYM_ENABLED false
+
 #define FORCE_LANDSCAPE_ORIENTATION true
 #define FORCE_BACKLIGHT_ON false
 

--- a/daemon/src/keymapping.cpp
+++ b/daemon/src/keymapping.cpp
@@ -6,23 +6,17 @@
 keymapping::keymapping(QObject *parent) :
     QObject(parent)
 {
-    shiftPressed = false;
-    ctrlPressed = false;
-    altPressed = false;
-    symPressed = false;
     pressedCode = 0;
 
-    stickyCtrlEnabled = false;
-    stickyAltEnabled = false;
-    stickySymEnabled = false;
+    shift = new modifierHandler("shift");
+    ctrl = new modifierHandler("ctrl");
+    alt = new modifierHandler("alt");
+    sym = new modifierHandler("sym");
 
-    ctrlWasHeldDown = false;
-    symWasHeldDown = false;
-    altWasHeldDown = false;
-
-    ctrlDown = false;
-    altDown = false;
-    symDown = false;
+    connect(shift, SIGNAL(changed()), this, SIGNAL(shiftChanged()));
+    connect(ctrl, SIGNAL(changed()), this, SIGNAL(ctrlChanged()));
+    connect(alt, SIGNAL(changed()), this, SIGNAL(altChanged()));
+    connect(sym, SIGNAL(changed()), this, SIGNAL(symChanged()));
 }
 
 /* REV 2 Keyboard mapping
@@ -44,10 +38,11 @@ void keymapping::process(QByteArray inputReport)
     QList< QPair<int,int> > retKey;
     char irCode = 0;
 
-    bool __shiftPressed = false;
-    ctrlDown = false;
-    altDown = false;
-    symDown = false;
+    bool leftShiftDown = false;
+    bool shiftDown = false;
+    bool ctrlDown = false;
+    bool altDown = false;
+    bool symDown = false;
 
     printf("Processing report: ");
     for (n=0 ; n<inputReport.count() ; n++)
@@ -64,9 +59,9 @@ void keymapping::process(QByteArray inputReport)
     /* First check modifiers from modifier byte */
     if (inputReport.at(3) & 0x02) symDown = true;
     if (inputReport.at(3) & 0x08) ctrlDown = true;
-    if (inputReport.at(3) & 0x10) __shiftPressed = true;
+    if (inputReport.at(3) & 0x10) leftShiftDown = true;
     /* And other modifiers from the usage codes */
-    if (ir.contains(0xEA)) { __shiftPressed = true; ir.remove(ir.indexOf(0xEA), 1); }
+    if (ir.contains(0xEA)) { shiftDown = true; ir.remove(ir.indexOf(0xEA), 1); }
     if (ir.contains(0xCF)) { altDown = true; ir.remove(ir.indexOf(0xCF), 1); }
     if (ir.contains(0xBF)) { ctrlDown = true; ir.remove(ir.indexOf(0xBF), 1); }
     if (ir.contains(0xED)) { symDown = true; ir.remove(ir.indexOf(0xED), 1); }
@@ -78,88 +73,17 @@ void keymapping::process(QByteArray inputReport)
             ir.append(0xE9);
     }
 
-    if (__shiftPressed != shiftPressed)
-    {
-        shiftPressed = __shiftPressed;
-        emit shiftChanged();
-    }
+    if (leftShiftDown && symDown)
+        emit toggleCapsLock();
 
-    /* CTRL */
-    if (stickyCtrlEnabled && ctrlDown && ctrlPressed && !ir.isEmpty())
-    {
-        ctrlWasHeldDown = true;
-    }
-
-    if (stickyCtrlEnabled && ctrlDown && ir.isEmpty() && !pressedCode)
-    {
-        releaseStickyModifiers();
-        ctrlPressed = !ctrlPressed;
-        emit ctrlChanged();
-    }
-    else if (!stickyCtrlEnabled && (ctrlDown != ctrlPressed))
-    {
-        ctrlPressed = ctrlDown;
-        emit ctrlChanged();
-    }
-
-    /* ALT */
-    if (stickyAltEnabled && altDown && altPressed && !ir.isEmpty())
-    {
-        altWasHeldDown = true;
-    }
-
-    if (stickyAltEnabled && altDown && ir.isEmpty() && !pressedCode)
-    {
-        releaseStickyModifiers();
-        altPressed = !altPressed;
-        emit altChanged();
-    }
-    else if (!stickyAltEnabled && (altDown != altPressed))
-    {
-        altPressed = altDown;
-        emit altChanged();
-    }
-
-    /* SYM */
-    if (stickySymEnabled && symDown && symPressed && !ir.isEmpty())
-    {
-        symWasHeldDown = true;
-    }
-
-    if (stickySymEnabled && symDown && ir.isEmpty() && !pressedCode)
-    {
-        releaseStickyModifiers();
-        symPressed = !symPressed;
-        emit symChanged();
-    }
-    else if (!stickySymEnabled && (symDown != symPressed))
-    {
-        symPressed = symDown;
-        emit symChanged();
-    }
+    shift->set(leftShiftDown || shiftDown, ir.isEmpty());
+    ctrl->set(ctrlDown, ir.isEmpty());
+    alt->set(altDown, ir.isEmpty());
+    sym->set(symDown, ir.isEmpty());
 
     /* Shortcut out if no actual key pressed */
     if (ir.length() == 0)
     {
-        if (ctrlWasHeldDown && !ctrlDown && ctrlPressed)
-        {
-            ctrlWasHeldDown = false;
-            ctrlPressed = false;
-            emit ctrlChanged();
-        }
-        if (altWasHeldDown && !altDown && altPressed)
-        {
-            altWasHeldDown = false;
-            altPressed = false;
-            emit altChanged();
-        }
-        if (symWasHeldDown && !symDown && symPressed)
-        {
-            symWasHeldDown = false;
-            symPressed = false;
-            emit symChanged();
-        }
-
         if (pressedCode)
         {
             pressedCode = 0;
@@ -170,7 +94,7 @@ void keymapping::process(QByteArray inputReport)
     }
 
     /* Check for new code in report. */
-    for(int i=ir.length()-1 ; i>=0 ; --i)
+    for (int i=ir.length()-1 ; i >= 0 ; --i)
     {
         if (!_prevInputReport.contains(ir.at(i)))
         {
@@ -179,20 +103,7 @@ void keymapping::process(QByteArray inputReport)
         }
     }
 
-    if (!symPressed && irCode) /* Without SYM modifier */
-    {
-        int i = 0;
-        while (lut_plain[i])
-        {
-            if (irCode == lut_plain[i])
-            {
-                retKey.append(qMakePair(lut_plain[i+1], lut_plain[i+2]));
-                break;
-            }
-            i += 3;
-        }
-    }
-    else if (symPressed && irCode) /* With SYM modifier */
+    if (sym->pressed && irCode) /* With SYM modifier */
     {
         int i = 0;
         while (lut_sym[i])
@@ -205,6 +116,20 @@ void keymapping::process(QByteArray inputReport)
             i += 3;
         }
     }
+    else if (irCode) /* Without SYM modifier */
+    {
+        int i = 0;
+        while (lut_plain[i])
+        {
+            if (irCode == lut_plain[i])
+            {
+                retKey.append(qMakePair(lut_plain[i+1], lut_plain[i+2]));
+                break;
+            }
+            i += 3;
+        }
+    }
+
 
     /* If key is changed on the fly without break... emit released */
     if (pressedCode)
@@ -227,23 +152,12 @@ void keymapping::process(QByteArray inputReport)
     _prevInputReport = ir;
 }
 
-void keymapping::releaseStickyModifiers()
+void keymapping::releaseStickyModifiers(bool force)
 {
-    if (ctrlPressed && !ctrlDown)
-    {
-        ctrlPressed = false;
-        emit ctrlChanged();
-    }
-    if (altPressed && !altDown)
-    {
-        altPressed = false;
-        emit altChanged();
-    }
-    if (symPressed && !symDown)
-    {
-        symPressed = false;
-        emit symChanged();
-    }
+    shift->clear(force);
+    ctrl->clear(force);
+    alt->clear(force);
+    sym->clear(force);
 }
 
 void keymapping::setLayout(QString toLayout)

--- a/daemon/src/keymapping.h
+++ b/daemon/src/keymapping.h
@@ -5,6 +5,7 @@
 #include <QList>
 #include <QPair>
 #include <linux/input.h>
+#include "modifierhandler.h"
 
 #define FORCE_SHIFT    (1)
 #define FORCE_ALT      (2)
@@ -25,16 +26,12 @@ public:
 
     void process(QByteArray inputReport);
 
-    void releaseStickyModifiers();
+    void releaseStickyModifiers(bool force = false);
 
-    bool shiftPressed;
-    bool ctrlPressed;
-    bool altPressed;
-    bool symPressed;
-
-    bool stickyCtrlEnabled;
-    bool stickyAltEnabled;
-    bool stickySymEnabled;
+    modifierHandler *shift;
+    modifierHandler *ctrl;
+    modifierHandler *alt;
+    modifierHandler *sym;
 
     void setLayout(QString toLayout);
 
@@ -45,18 +42,12 @@ signals:
     void symChanged();
     void keyPressed(QList< QPair<int, int> > keyCode);
     void keyReleased();
+    void toggleCapsLock();
 
 public slots:
 
 private:
     bool keyIsPressed;
-
-    bool ctrlDown;
-    bool ctrlWasHeldDown;
-    bool altDown;
-    bool altWasHeldDown;
-    bool symDown;
-    bool symWasHeldDown;
 
     char pressedCode;
     QByteArray _prevInputReport;

--- a/daemon/src/modifierhandler.cpp
+++ b/daemon/src/modifierhandler.cpp
@@ -1,0 +1,120 @@
+#include <stdio.h>
+#include "modifierhandler.h"
+
+modifierHandler::modifierHandler(QString name, QObject *parent) :
+    QObject(parent)
+{
+    _name = name;
+
+    mode = Normal;
+    pressed = false;
+    down = false;
+    locked = false;
+
+    _wasHeldDown = false;
+    _lockCount = 0;
+
+    printf("modifierHandler for \"%s\"\n", qPrintable(_name));
+}
+
+void modifierHandler::set(bool state, bool alone)
+{
+    bool newPressed = pressed;
+
+    /* In normal mode, just follow the state */
+    if (mode == Normal)
+    {
+        newPressed = state;
+    }
+    else
+    {
+         /* sticky or lock, but held while another key is being presed */
+        if ((mode == Sticky || mode == Lock) && state && down && !alone)
+        {
+            _wasHeldDown = true;
+        }
+
+        /* If something was pressed while held, release when released */
+        if ((mode == Sticky || mode == Lock) && !state && _wasHeldDown)
+        {
+            _wasHeldDown = false;
+            _lockCount = 0;
+            locked = false;
+            newPressed = false;
+        }
+        /* Just pressing toggles if sticky */
+        else if (mode == Sticky && state && alone && !_wasHeldDown)
+        {
+            newPressed = !pressed;
+        }
+            /* Reset lock count if anything else pressed */
+        else if (mode == Lock && !locked && !alone && _lockCount != 3)
+        {
+            _lockCount = 0;
+        }
+        /* If just modifier key is pressed */
+        else if (mode == Lock && alone)
+        {
+            if (!down && state && (_lockCount == 0))
+            {
+                newPressed = true;
+                _lockCount = 1;
+            }
+            else if (down && !state && (_lockCount == 1))
+            {
+                newPressed = false;
+                _lockCount = 2;
+            }
+            else if (!down && state && (_lockCount == 2))
+            {
+                _lockCount = 3;
+                newPressed = true;
+                locked = true;
+            }
+            else if (!down && state && (_lockCount == 3))
+            {
+                _lockCount = 0;
+                newPressed = true;
+                locked = false;
+            }
+            else if (down && !state && (_lockCount == 0))
+            {
+                newPressed = false;
+            }
+        }
+    }
+
+    down = state;
+
+    /* So, was the pressed -state actually to be changed? */
+    if (newPressed != pressed)
+    {
+        pressed = newPressed;
+        printf("%s changed to %s\n", qPrintable(_name), pressed ? "down" : "up");
+        emit changed();
+    }
+}
+
+void modifierHandler::clear(bool force)
+{
+    /* If tere is something to clear, clear */
+    if ((pressed && !down && !locked) || force)
+    {
+        locked = false;
+        _lockCount = 0;
+        _wasHeldDown = false;
+
+        pressed = false;
+        emit changed();
+    }
+}
+
+void modifierHandler::setMode(KeyMode newMode)
+{
+    /* Change mode and clear states */
+    if (newMode != mode)
+    {
+        mode = newMode;
+        clear(true);
+    }
+}

--- a/daemon/src/modifierhandler.h
+++ b/daemon/src/modifierhandler.h
@@ -1,0 +1,42 @@
+#ifndef MODIFIERHANDLER_H
+#define MODIFIERHANDLER_H
+
+#include <QObject>
+
+class modifierHandler : public QObject
+{
+    Q_OBJECT
+public:
+    explicit modifierHandler(QString name, QObject *parent = 0);
+
+    typedef enum KeyMode
+    {
+        Normal = 0,
+        Sticky,
+        Lock
+    } KeyMode;
+
+    void set(bool state, bool alone);
+    void clear(bool force = false);
+
+    void setMode(KeyMode newMode);
+
+    KeyMode mode;
+
+    bool pressed;
+    bool down;
+    bool locked;
+
+signals:
+    void changed();
+
+public slots:
+
+private:
+    QString _name;
+    bool _wasHeldDown;
+    int _lockCount;
+
+};
+
+#endif // MODIFIERHANDLER_H

--- a/daemon/src/tohkeyboard.cpp
+++ b/daemon/src/tohkeyboard.cpp
@@ -20,6 +20,7 @@
 #include "uinputif.h"
 #include "defaultSettings.h"
 #include "eepromdriver.h"
+#include "modifierhandler.h"
 
 static const char *SERVICE = SERVICE_NAME;
 static const char *PATH = "/";
@@ -33,7 +34,6 @@ Tohkbd::Tohkbd(QObject *parent) :
     dbusRegistered = false;
     interruptsEnabled = false;
     vddEnabled = false;
-    capsLockSeq = 0;
     vkbLayoutIsTohkbd = false;
     currentActiveLayout = QString();
     currentOrientationLock = QString();
@@ -48,6 +48,7 @@ Tohkbd::Tohkbd(QObject *parent) :
     ssNotifyReplacesId = 0;
     ssFilename = QString();
     gpioInterruptCounter = 0;
+    capsLock = false;
 
     tohkbd2user = new QDBusInterface("com.kimmoli.tohkbd2user", "/", "com.kimmoli.tohkbd2user", QDBusConnection::sessionBus(), this);
     tohkbd2user->setTimeout(2000);
@@ -117,6 +118,7 @@ Tohkbd::Tohkbd(QObject *parent) :
     connect(keymap, SIGNAL(ctrlChanged()), this, SLOT(handleCtrlChanged()));
     connect(keymap, SIGNAL(altChanged()), this, SLOT(handleAltChanged()));
     connect(keymap, SIGNAL(symChanged()), this, SLOT(handleSymChanged()));
+    connect(keymap, SIGNAL(toggleCapsLock()), this, SLOT(toggleCapsLock()));
     connect(keymap, SIGNAL(keyPressed(QList< QPair<int, int> >)), this, SLOT(handleKeyPressed(QList< QPair<int, int> >)));
     connect(keymap, SIGNAL(keyReleased()), this, SLOT(handleKeyReleased()));
 
@@ -358,12 +360,35 @@ void Tohkbd::controlLeds(bool restore)
 
     if (restore)
     {
-        tca8424->setLeds(  (keymap->symPressed  ? LED_SYMLOCK_ON   : LED_SYMLOCK_OFF)
-                         | (keymap->ctrlPressed ? LED_SYMLOCK_ON   : LED_SYMLOCK_OFF)
-                         | (keymap->altPressed  ? LED_SYMLOCK_ON   : LED_SYMLOCK_OFF)
-                         | ((capsLockSeq == 3)  ? LED_CAPSLOCK_ON  : LED_CAPSLOCK_OFF)
-                         | (selfieLedOn         ? LED_SELFIE_ON    : LED_SELFIE_OFF)
-                         | (forceBacklightOn    ? LED_BACKLIGHT_ON : LED_BACKLIGHT_OFF) );
+        /* If backlight was on, do not turn it off */
+        int i = LED_CAPSLOCK_OFF | LED_SYMLOCK_OFF | LED_SELFIE_OFF;
+
+        if (((keymap->shift->mode == modifierHandler::Sticky) && keymap->shift->pressed)
+          || ((keymap->shift->mode == modifierHandler::Lock) && keymap->shift->locked))
+            i |= LED_SYMLOCK_ON;
+
+        if (((keymap->ctrl->mode == modifierHandler::Sticky) && keymap->ctrl->pressed)
+          || ((keymap->ctrl->mode == modifierHandler::Lock) && keymap->ctrl->locked))
+            i |= LED_SYMLOCK_ON;
+
+        if (((keymap->alt->mode == modifierHandler::Sticky) && keymap->alt->pressed)
+          || ((keymap->alt->mode == modifierHandler::Lock) && keymap->alt->locked))
+            i |= LED_SYMLOCK_ON;
+
+        if (((keymap->sym->mode == modifierHandler::Sticky) && keymap->sym->pressed)
+          || ((keymap->sym->mode == modifierHandler::Lock) && keymap->sym->locked))
+            i |= LED_SYMLOCK_ON;
+
+        if (capsLock)
+            i |= LED_CAPSLOCK_ON;
+
+        if (selfieLedOn)
+            i |= LED_SELFIE_ON;
+
+        if (forceBacklightOn)
+            i |= LED_BACKLIGHT_ON;
+
+        tca8424->setLeds(i);
     }
     else
     {
@@ -455,13 +480,10 @@ void Tohkbd::handleKeyPressed(QList< QPair<int, int> > keyCode)
         slideEventEmitted = true;
     }
 
-    if ((capsLockSeq == 1 || capsLockSeq == 2)) /* Abort caps-lock if other key pressed */
-        capsLockSeq = 0;
-
     checkDoWeNeedBacklight();
 
     /* alt+TAB is the task-switcher */
-    if (keymap->altPressed && keyCode.at(0).first == KEY_TAB)
+    if (keymap->alt->pressed && keyCode.at(0).first == KEY_TAB)
     {
         if (!taskSwitcherVisible)
         {
@@ -528,7 +550,7 @@ void Tohkbd::handleKeyPressed(QList< QPair<int, int> > keyCode)
 
     /* Catch ctrl-alt-del (Works only from left ctrl) */
 
-    if (keymap->altPressed && keymap->ctrlPressed && keyCode.at(0).first == KEY_DELETE)
+    if (keymap->alt->pressed && keymap->ctrl->pressed && keyCode.at(0).first == KEY_DELETE)
     {
         printf("Requesting user daemon to reset with remorse.\n");
 
@@ -542,20 +564,26 @@ void Tohkbd::handleKeyPressed(QList< QPair<int, int> > keyCode)
     {
         for (int i=0; i<keyCode.count(); i++)
         {
-            bool tweakCapsLock = (capsLockSeq == 3 && ((keyCode.at(i).first >= KEY_Q && keyCode.at(i).first <= KEY_P)
-                                                       || (keyCode.at(i).first >= KEY_A && keyCode.at(i).first <= KEY_L)
-                                                       || (keyCode.at(i).first >= KEY_Z && keyCode.at(i).first <= KEY_M) ));
+            bool tweakCapsLock = (capsLock && ((keyCode.at(i).first >= KEY_Q && keyCode.at(i).first <= KEY_P)
+                                           || (keyCode.at(i).first >= KEY_A && keyCode.at(i).first <= KEY_L)
+                                           || (keyCode.at(i).first >= KEY_Z && keyCode.at(i).first <= KEY_M) ));
 
             /* Some of the keys require shift pressed to get correct symbol */
             if (keyCode.at(i).second & FORCE_COMPOSE)
                 uinputif->sendUinputKeyPress(KEY_COMPOSE, 1);
             if ((keyCode.at(i).second & FORCE_RIGHTALT))
                 uinputif->sendUinputKeyPress(KEY_RIGHTALT, 1);
-            if ((keyCode.at(i).second & FORCE_SHIFT) || keymap->shiftPressed || tweakCapsLock)
+//            if ((keyCode.at(i).second & FORCE_SHIFT) || keymap->shift->pressed || tweakCapsLock)
+//                uinputif->sendUinputKeyPress(KEY_LEFTSHIFT, 1);
+//            if ((keyCode.at(i).second & FORCE_ALT) || keymap->alt->pressed)
+//                uinputif->sendUinputKeyPress(KEY_LEFTALT, 1);
+//            if ((keyCode.at(i).second & FORCE_CTRL) || keymap->ctrl->pressed)
+//                uinputif->sendUinputKeyPress(KEY_LEFTCTRL, 1);
+            if ((keyCode.at(i).second & FORCE_SHIFT) || tweakCapsLock)
                 uinputif->sendUinputKeyPress(KEY_LEFTSHIFT, 1);
-            if ((keyCode.at(i).second & FORCE_ALT) || keymap->altPressed)
+            if ((keyCode.at(i).second & FORCE_ALT))
                 uinputif->sendUinputKeyPress(KEY_LEFTALT, 1);
-            if ((keyCode.at(i).second & FORCE_CTRL) || keymap->ctrlPressed)
+            if ((keyCode.at(i).second & FORCE_CTRL))
                 uinputif->sendUinputKeyPress(KEY_LEFTCTRL, 1);
 
             /* Mimic key pressing */
@@ -563,11 +591,16 @@ void Tohkbd::handleKeyPressed(QList< QPair<int, int> > keyCode)
             QThread::msleep(KEYREPEAT_RATE);
             uinputif->sendUinputKeyPress(keyCode.at(i).first, 0);
 
-            if ((keyCode.at(i).second & FORCE_CTRL) || keymap->ctrlPressed)
+//            if ((keyCode.at(i).second & FORCE_CTRL) || keymap->ctrl->pressed)
+//                uinputif->sendUinputKeyPress(KEY_LEFTCTRL, 0);
+//            if ((keyCode.at(i).second & FORCE_ALT) || keymap->alt->pressed)
+//                uinputif->sendUinputKeyPress(KEY_LEFTALT, 0);
+//            if ((keyCode.at(i).second & FORCE_SHIFT) || keymap->shift->pressed || tweakCapsLock)
+            if ((keyCode.at(i).second & FORCE_CTRL))
                 uinputif->sendUinputKeyPress(KEY_LEFTCTRL, 0);
-            if ((keyCode.at(i).second & FORCE_ALT) || keymap->altPressed)
+            if ((keyCode.at(i).second & FORCE_ALT))
                 uinputif->sendUinputKeyPress(KEY_LEFTALT, 0);
-            if ((keyCode.at(i).second & FORCE_SHIFT) || keymap->shiftPressed || tweakCapsLock)
+            if ((keyCode.at(i).second & FORCE_SHIFT) || tweakCapsLock)
                 uinputif->sendUinputKeyPress(KEY_LEFTSHIFT, 0);
             if ((keyCode.at(i).second & FORCE_RIGHTALT))
                 uinputif->sendUinputKeyPress(KEY_RIGHTALT, 0);
@@ -611,64 +644,34 @@ void Tohkbd::handleKeyReleased()
  */
 void Tohkbd::handleShiftChanged()
 {
+    controlLeds(true);
     checkDoWeNeedBacklight();
 
-    if (keymap->shiftPressed && capsLockSeq == 0) /* Shift pressed first time */
-        capsLockSeq = 1;
-    else if (!keymap->shiftPressed && capsLockSeq == 1) /* Shift released */
-        capsLockSeq = 2;
-    else if (keymap->shiftPressed && capsLockSeq == 2) /* Shift pressed 2nd time */
-    {
-        capsLockSeq = 3;
-        uinputif->sendUinputKeyPress(KEY_CAPSLOCK, 1);
-        QThread::msleep(KEYREPEAT_RATE);
-        uinputif->sendUinputKeyPress(KEY_CAPSLOCK, 0);
-        uinputif->synUinputDevice();
-        tca8424->setLeds(LED_CAPSLOCK_ON);
-        printf("CapsLock on\n");
-    }
-    else if (keymap->shiftPressed && capsLockSeq == 3) /* Shift pressed 3rd time */
-    {
-        capsLockSeq = 0;
-        uinputif->sendUinputKeyPress(KEY_CAPSLOCK, 1);
-        QThread::msleep(KEYREPEAT_RATE);
-        uinputif->sendUinputKeyPress(KEY_CAPSLOCK, 0);
-        uinputif->synUinputDevice();
-        tca8424->setLeds(LED_CAPSLOCK_OFF);
-        printf("CapsLock off\n");
-    }
+    uinputif->sendUinputKeyPress(KEY_LEFTSHIFT, keymap->shift->pressed ? 1 : 0);
+    QThread::msleep(KEYREPEAT_RATE);
+    uinputif->synUinputDevice();
 }
 
 void Tohkbd::handleCtrlChanged()
 {
+    controlLeds(true);
     checkDoWeNeedBacklight();
 
-    if ((capsLockSeq == 1 || capsLockSeq == 2)) /* Abort caps-lock if other key pressed */
-        capsLockSeq = 0;
-
-    printf("ctrl changed %s\n", keymap->ctrlPressed ? "down" : "up");
-
-    if (keymap->stickyCtrlEnabled)
-    {
-        tca8424->setLeds(keymap->ctrlPressed ? LED_SYMLOCK_ON : LED_SYMLOCK_OFF);
-    }
+    uinputif->sendUinputKeyPress(KEY_LEFTCTRL, keymap->ctrl->pressed ? 1 : 0);
+    QThread::msleep(KEYREPEAT_RATE);
+    uinputif->synUinputDevice();
 }
 
 void Tohkbd::handleAltChanged()
 {
+    controlLeds(true);
     checkDoWeNeedBacklight();
 
-    if ((capsLockSeq == 1 || capsLockSeq == 2)) /* Abort caps-lock if other key pressed */
-        capsLockSeq = 0;
+    uinputif->sendUinputKeyPress(KEY_LEFTALT, keymap->alt->pressed ? 1 : 0);
+    QThread::msleep(KEYREPEAT_RATE);
+    uinputif->synUinputDevice();
 
-    printf("alt changed %s\n", keymap->altPressed ? "down" : "up");
-
-    if (keymap->stickyAltEnabled)
-    {
-        tca8424->setLeds(keymap->altPressed ? LED_SYMLOCK_ON : LED_SYMLOCK_OFF);
-    }
-
-    if (!keymap->altPressed && taskSwitcherVisible)
+    if (!keymap->alt->pressed && taskSwitcherVisible)
     {
         /* hide taskswitcher when alt is released
          * this will also activate selected application */
@@ -679,16 +682,32 @@ void Tohkbd::handleAltChanged()
 
 void Tohkbd::handleSymChanged()
 {
+    controlLeds(true);
     checkDoWeNeedBacklight();
+}
 
-    if ((capsLockSeq == 1 || capsLockSeq == 2)) /* Abort caps-lock if other key pressed */
-        capsLockSeq = 0;
 
-    if (keymap->stickySymEnabled)
+void Tohkbd::toggleCapsLock()
+{
+    uinputif->sendUinputKeyPress(KEY_CAPSLOCK, 1);
+    QThread::msleep(KEYREPEAT_RATE);
+    uinputif->sendUinputKeyPress(KEY_CAPSLOCK, 0);
+    uinputif->synUinputDevice();
+
+    capsLock = !capsLock;
+
+    if (capsLock)
     {
-        tca8424->setLeds(keymap->symPressed ? LED_SYMLOCK_ON : LED_SYMLOCK_OFF);
+        tca8424->setLeds(LED_CAPSLOCK_ON);
+        printf("CapsLock on\n");
+    }
+    else
+    {
+        tca8424->setLeds(LED_CAPSLOCK_OFF);
+        printf("CapsLock off\n");
     }
 }
+
 
 /* Read first line from a text file
  * returns empty QString if failed
@@ -868,6 +887,7 @@ void Tohkbd::presenceTimerTimeout()
 void Tohkbd::reloadSettings()
 {
     QSettings settings(QSettings::SystemScope, "harbour-tohkbd2", "tohkbd2");
+
     settings.beginGroup("vkb");
     currentActiveLayout = settings.value("activeLayout", "").toString();
     settings.endGroup();
@@ -895,25 +915,51 @@ void Tohkbd::reloadSettings()
     }
     settings.endGroup();
 
-    settings.beginGroup("generalsettings");
-    backlightTimer->setInterval(settings.value("backlightTimeout", BACKLIGHT_TIMEOUT).toInt());
-    backlightLuxThreshold = settings.value("backlightLuxThreshold", BACKLIGHT_LUXTHRESHOLD).toInt();
-    backlightEnabled = settings.value("backlightEnabled", BACKLIGHT_ENABLED).toBool();
-    keyRepeatDelay = settings.value("keyRepeatDelay", KEYREPEAT_DELAY).toInt();
-    keyRepeatRate = settings.value("keyRepeatRate", KEYREPEAT_RATE).toInt();
-    keymap->stickyCtrlEnabled = settings.value("stickyCtrlEnabled", STICKY_CTRL_ENABLED).toBool();
-    keymap->stickyAltEnabled = settings.value("stickyAltEnabled", STICKY_ALT_ENABLED).toBool();
-    keymap->stickySymEnabled = settings.value("stickySymEnabled", STICKY_SYM_ENABLED).toBool();
-    forceLandscapeOrientation = settings.value("forceLandscapeOrientation", FORCE_LANDSCAPE_ORIENTATION).toBool();
-    forceBacklightOn = settings.value("forceBacklightOn", FORCE_BACKLIGHT_ON).toBool();
-    settings.endGroup();
-
     settings.beginGroup("orientation");
     currentOrientationLock = settings.value("originalOrientation", QString()).toString();
     settings.endGroup();
 
     settings.beginGroup("layoutSettings");
     masterLayout = settings.value("masterLayout", QString(MASTER_LAYOUT)).toString();
+    settings.endGroup();
+
+    settings.beginGroup("generalsettings");
+    backlightTimer->setInterval(settings.value("backlightTimeout", BACKLIGHT_TIMEOUT).toInt());
+    backlightLuxThreshold = settings.value("backlightLuxThreshold", BACKLIGHT_LUXTHRESHOLD).toInt();
+    backlightEnabled = settings.value("backlightEnabled", BACKLIGHT_ENABLED).toBool();
+    keyRepeatDelay = settings.value("keyRepeatDelay", KEYREPEAT_DELAY).toInt();
+    keyRepeatRate = settings.value("keyRepeatRate", KEYREPEAT_RATE).toInt();
+
+    if (settings.value("stickyShiftEnabled", STICKY_SHIFT_ENABLED).toBool())
+        keymap->shift->setMode(modifierHandler::Sticky);
+    else if (settings.value("lockingShiftEnabled", LOCKING_SHIFT_ENABLED).toBool())
+        keymap->shift->setMode(modifierHandler::Lock);
+    else
+        keymap->shift->setMode(modifierHandler::Normal);
+
+    if (settings.value("stickyCtrlEnabled", STICKY_CTRL_ENABLED).toBool())
+        keymap->ctrl->setMode(modifierHandler::Sticky);
+    else if (settings.value("lockingCtrlEnabled", LOCKING_CTRL_ENABLED).toBool())
+        keymap->ctrl->setMode(modifierHandler::Lock);
+    else
+        keymap->ctrl->setMode(modifierHandler::Normal);
+
+    if (settings.value("stickyAltEnabled", STICKY_ALT_ENABLED).toBool())
+        keymap->alt->setMode(modifierHandler::Sticky);
+    else if (settings.value("lockingAltEnabled", LOCKING_ALT_ENABLED).toBool())
+        keymap->alt->setMode(modifierHandler::Lock);
+    else
+        keymap->alt->setMode(modifierHandler::Normal);
+
+    if (settings.value("stickySymEnabled", STICKY_SYM_ENABLED).toBool())
+        keymap->sym->setMode(modifierHandler::Sticky);
+    else if (settings.value("lockingSymEnabled", LOCKING_SYM_ENABLED).toBool())
+        keymap->sym->setMode(modifierHandler::Lock);
+    else
+        keymap->sym->setMode(modifierHandler::Normal);
+
+    forceLandscapeOrientation = settings.value("forceLandscapeOrientation", FORCE_LANDSCAPE_ORIENTATION).toBool();
+    forceBacklightOn = settings.value("forceBacklightOn", FORCE_BACKLIGHT_ON).toBool();
     settings.endGroup();
 }
 
@@ -994,54 +1040,55 @@ void Tohkbd::setSettingInt(const QString &key, const int &value)
 
     if (key == "backlightTimeout" && value >= 100 && value <= 5000)
     {
-        backlightTimer->setInterval(value);
         settings.beginGroup("generalsettings");
         settings.setValue("backlightTimeout", value);
+        backlightTimer->setInterval(value);
         settings.endGroup();
     }
     else if (key == "backlightLuxThreshold" && value >= 1 && value <= 50)
     {
-        backlightLuxThreshold = value;
         settings.beginGroup("generalsettings");
         settings.setValue("backlightLuxThreshold", value);
+        backlightLuxThreshold = value;
         settings.endGroup();
     }
     else if (key == "keyRepeatDelay" && value >= 50 && value <= 500)
     {
-        keyRepeatDelay = value;
         settings.beginGroup("generalsettings");
         settings.setValue("keyRepeatDelay", value);
+        keyRepeatDelay = value;
         settings.endGroup();
     }
     else if (key == "keyRepeatRate" && value >= 25 && value <= 100)
     {
-        keyRepeatRate = value;
         settings.beginGroup("generalsettings");
         settings.setValue("keyRepeatRate", value);
+        keyRepeatRate = value;
         settings.endGroup();
     }
     else if (key == "backlightEnabled" && (value == 0 || value == 1))
     {
-        backlightEnabled = (value == 1);
         settings.beginGroup("generalsettings");
         settings.setValue("backlightEnabled", (value == 1));
+        backlightEnabled = (value == 1);
         settings.endGroup();
         checkDoWeNeedBacklight();
     }
     else if (key == "forceBacklightOn" && (value == 0 || value == 1))
     {
-        forceBacklightOn = (value == 1);
         settings.beginGroup("generalsettings");
         settings.setValue("forceBacklightOn", (value == 1));
+        forceBacklightOn = (value == 1);
         settings.endGroup();
         checkDoWeNeedBacklight();
     }
     else if (key == "forceLandscapeOrientation" && (value == 0 || value == 1))
     {
-        forceLandscapeOrientation = (value == 1);
         settings.beginGroup("generalsettings");
         settings.setValue("forceLandscapeOrientation", (value == 1));
+        forceLandscapeOrientation = (value == 1);
         settings.endGroup();
+
         if (value == 0 && !currentOrientationLock.isEmpty())
         {
             QList<QVariant> args;
@@ -1055,30 +1102,64 @@ void Tohkbd::setSettingInt(const QString &key, const int &value)
             tohkbd2user->callWithArgumentList(QDBus::AutoDetect, "setOrientationLock", args);
         }
     }
+    else if (key == "stickyShiftEnabled" && (value == 0 || value == 1))
+    {
+        settings.beginGroup("generalsettings");
+        settings.setValue("stickyShiftEnabled", (value == 1));
+        keymap->shift->setMode((value == 1) ? modifierHandler::Sticky : modifierHandler::Normal);
+        settings.endGroup();
+    }
     else if (key == "stickyCtrlEnabled" && (value == 0 || value == 1))
     {
-        keymap->releaseStickyModifiers();
-        keymap->stickyCtrlEnabled = (value == 1);
         settings.beginGroup("generalsettings");
         settings.setValue("stickyCtrlEnabled", (value == 1));
+        keymap->ctrl->setMode((value == 1) ? modifierHandler::Sticky : modifierHandler::Normal);
         settings.endGroup();
     }
     else if (key == "stickyAltEnabled" && (value == 0 || value == 1))
     {
-        keymap->releaseStickyModifiers();
-        keymap->stickyAltEnabled = (value == 1);
         settings.beginGroup("generalsettings");
         settings.setValue("stickyAltEnabled", (value == 1));
+        keymap->alt->setMode((value == 1) ? modifierHandler::Sticky : modifierHandler::Normal);
         settings.endGroup();
     }
     else if (key == "stickySymEnabled" && (value == 0 || value == 1))
     {
-        keymap->releaseStickyModifiers();
-        keymap->stickySymEnabled = (value == 1);
         settings.beginGroup("generalsettings");
         settings.setValue("stickySymEnabled", (value == 1));
+        keymap->sym->setMode((value == 1) ? modifierHandler::Sticky : modifierHandler::Normal);
         settings.endGroup();
     }
+    else if (key == "lockingShiftEnabled" && (value == 0 || value == 1))
+    {
+        settings.beginGroup("generalsettings");
+        settings.setValue("lockingShiftEnabled", (value == 1));
+        keymap->shift->setMode((value == 1) ? modifierHandler::Lock : modifierHandler::Normal);
+        settings.endGroup();
+    }
+    else if (key == "lockingCtrlEnabled" && (value == 0 || value == 1))
+    {
+        settings.beginGroup("generalsettings");
+        settings.setValue("lockingCtrlEnabled", (value == 1));
+        keymap->ctrl->setMode((value == 1) ? modifierHandler::Lock : modifierHandler::Normal);
+        settings.endGroup();
+    }
+    else if (key == "lockingAltEnabled" && (value == 0 || value == 1))
+    {
+        settings.beginGroup("generalsettings");
+        settings.setValue("lockingAltEnabled", (value == 1));
+        keymap->alt->setMode((value == 1) ? modifierHandler::Lock : modifierHandler::Normal);
+        settings.endGroup();
+    }
+    else if (key == "lockingSymEnabled" && (value == 0 || value == 1))
+    {
+        settings.beginGroup("generalsettings");
+        settings.setValue("lockingSymEnabled", (value == 1));
+        keymap->sym->setMode((value == 1) ? modifierHandler::Lock : modifierHandler::Normal);
+        settings.endGroup();
+    }
+
+    keymap->releaseStickyModifiers(true);
 }
 
 void Tohkbd::setSettingString(const QString &key, const QString &value)

--- a/daemon/src/tohkeyboard.h
+++ b/daemon/src/tohkeyboard.h
@@ -52,6 +52,8 @@ public slots:
     void handleKeyPressed(QList< QPair<int, int> > keyCode);
     void handleKeyReleased();
 
+    void toggleCapsLock();
+
     /* timer timeouts */
     void backlightTimerTimeout();
     void presenceTimerTimeout();
@@ -102,7 +104,6 @@ private:
     tca8424driver *tca8424;
     keymapping *keymap;
 
-    int capsLockSeq;
     int backlightLuxThreshold;
     int keyRepeatDelay;
     int keyRepeatRate;
@@ -134,6 +135,7 @@ private:
     bool forceLandscapeOrientation;
     bool taskSwitcherVisible;
     bool selfieLedOn;
+    bool capsLock;
 
     QDBusInterface *tohkbd2user;
 

--- a/settings-ui/qml/pages/GeneralSettings.qml
+++ b/settings-ui/qml/pages/GeneralSettings.qml
@@ -55,7 +55,7 @@ Page
             {
                 width: parent.width - 2*Theme.paddingLarge
                 anchors.horizontalCenter: parent.horizontalCenter
-                label: qsTr("Timeout")
+                label: qsTr("Backlight timeout")
                 minimumValue: 100
                 maximumValue: 5000
                 value: settings["backlightTimeout"]
@@ -121,7 +121,7 @@ Page
             {
                 width: parent.width - 2*Theme.paddingLarge
                 anchors.horizontalCenter: parent.horizontalCenter
-                label: qsTr("Delay")
+                label: qsTr("Repeat start delay")
                 minimumValue: 50
                 maximumValue: 500
                 value: settings["keyRepeatDelay"]
@@ -143,7 +143,7 @@ Page
             {
                 width: parent.width - 2*Theme.paddingLarge
                 anchors.horizontalCenter: parent.horizontalCenter
-                label: qsTr("Rate")
+                label: qsTr("Repeat rate")
                 minimumValue: 25
                 maximumValue: 100
                 value: settings["keyRepeatRate"]
@@ -170,11 +170,11 @@ Page
 
             SectionHeader
             {
-                text: qsTr("Sticky modifiers")
+                text: qsTr("Sticky and locking modifier keys")
             }
             Label
             {
-                text: qsTr("Sticky modifiers will toggle when pressed, they also work as normal modifier keys")
+                text: qsTr("Sticky modifiers will toggle when pressed once and released after pressing any other key. Locking modifier will lock on double-press and released on third. In both modes you can also use them as normal modifier keys")
                 wrapMode: Text.Wrap
                 font.pixelSize: Theme.fontSizeExtraSmall
                 color: Theme.secondaryColor
@@ -182,28 +182,126 @@ Page
                 anchors.horizontalCenter: parent.horizontalCenter
             }
 
-            TextSwitch
+            Row
             {
-                text: qsTr("Sticky Ctrl")
-                onCheckedChanged: settingsui.setSettingInt("stickyCtrlEnabled", checked ? 1 : 0)
                 width: parent.width - 2*Theme.paddingLarge
-                Component.onCompleted: checked = settings["stickyCtrlEnabled"]
+                TextSwitch
+                {
+                    id: stickyShift
+                    text: qsTr("Sticky Shift")
+                    onCheckedChanged:
+                    {
+                        if (checked)
+                            lockingShift.checked = false
+                        settingsui.setSettingInt("stickyShiftEnabled", checked ? 1 : 0)
+                    }
+                    width: parent.width/2
+                    Component.onCompleted: checked = settings["stickyShiftEnabled"]
+                }
+                TextSwitch
+                {
+                    id: lockingShift
+                    text: qsTr("Locking Shift")
+                    onCheckedChanged:
+                    {
+                        if (checked)
+                            stickyShift.checked = false
+                        settingsui.setSettingInt("lockingShiftEnabled", checked ? 1 : 0)
+                    }
+                    width: parent.width/2
+                    Component.onCompleted: checked = settings["lockingShiftEnabled"]
+                }
             }
-            TextSwitch
+            Row
             {
-                text: qsTr("Sticky Alt")
-                onCheckedChanged: settingsui.setSettingInt("stickyAltEnabled", checked ? 1 : 0)
                 width: parent.width - 2*Theme.paddingLarge
-                Component.onCompleted: checked = settings["stickyAltEnabled"]
+                TextSwitch
+                {
+                    id: stickyCtrl
+                    text: qsTr("Sticky Ctrl")
+                    onCheckedChanged:
+                    {
+                        if (checked)
+                            lockingCtrl.checked = false
+                        settingsui.setSettingInt("stickyCtrlEnabled", checked ? 1 : 0)
+                    }
+                    width: parent.width/2
+                    Component.onCompleted: checked = settings["stickyCtrlEnabled"]
+                }
+                TextSwitch
+                {
+                    id: lockingCtrl
+                    text: qsTr("Locking Ctrl")
+                    onCheckedChanged:
+                    {
+                        if (checked)
+                            stickyCtrl.checked = false
+                        settingsui.setSettingInt("lockingCtrlEnabled", checked ? 1 : 0)
+                    }
+                    width: parent.width/2
+                    Component.onCompleted: checked = settings["lockingCtrlEnabled"]
+                }
             }
-            TextSwitch
+            Row
             {
-                text: qsTr("Sticky Sym")
-                onCheckedChanged: settingsui.setSettingInt("stickySymEnabled", checked ? 1 : 0)
                 width: parent.width - 2*Theme.paddingLarge
-                Component.onCompleted: checked = settings["stickySymEnabled"]
+                TextSwitch
+                {
+                    id: stickyAlt
+                    text: qsTr("Sticky Alt")
+                    onCheckedChanged:
+                    {
+                        if (checked)
+                            lockingAlt.checked = false
+                        settingsui.setSettingInt("stickyAltEnabled", checked ? 1 : 0)
+                    }
+                    width: parent.width/2
+                    Component.onCompleted: checked = settings["stickyAltEnabled"]
+                }
+                TextSwitch
+                {
+                    id: lockingAlt
+                    text: qsTr("Locking Alt")
+                    onCheckedChanged:
+                    {
+                        if (checked)
+                            stickyAlt.checked = false;
+                        settingsui.setSettingInt("lockingAltEnabled", checked ? 1 : 0)
+                    }
+                    width: parent.width/2
+                    Component.onCompleted: checked = settings["lockingAltEnabled"]
+                }
             }
-
+            Row
+            {
+                width: parent.width - 2*Theme.paddingLarge
+                TextSwitch
+                {
+                    id: stickySym
+                    text: qsTr("Sticky Sym")
+                    onCheckedChanged:
+                    {
+                        if (checked)
+                            lockingSym.checked = false
+                        settingsui.setSettingInt("stickySymEnabled", checked ? 1 : 0)
+                    }
+                    width: parent.width/2
+                    Component.onCompleted: checked = settings["stickySymEnabled"]
+                }
+                TextSwitch
+                {
+                    id: lockingSym
+                    text: qsTr("Locking Sym")
+                    onCheckedChanged:
+                    {
+                        if (checked)
+                            stickySym.checked = false
+                        settingsui.setSettingInt("lockingSymEnabled", checked ? 1 : 0)
+                    }
+                    width: parent.width/2
+                    Component.onCompleted: checked = settings["lockingSymEnabled"]
+                }
+            }
         }
     }
 }

--- a/settings-ui/src/settingsui.cpp
+++ b/settings-ui/src/settingsui.cpp
@@ -95,9 +95,14 @@ QVariantMap SettingsUi::getCurrentSettings()
     map.insert("backlightEnabled", settings.value("backlightEnabled", BACKLIGHT_ENABLED).toBool());
     map.insert("forceLandscapeOrientation", settings.value("forceLandscapeOrientation", FORCE_LANDSCAPE_ORIENTATION).toBool());
     map.insert("forceBacklightOn", settings.value("forceBacklightOn", FORCE_BACKLIGHT_ON).toBool());
+    map.insert("stickyShiftEnabled", settings.value("stickyShiftEnabled", STICKY_SHIFT_ENABLED).toBool());
     map.insert("stickyCtrlEnabled", settings.value("stickyCtrlEnabled", STICKY_CTRL_ENABLED).toBool());
     map.insert("stickyAltEnabled", settings.value("stickyAltEnabled", STICKY_ALT_ENABLED).toBool());
     map.insert("stickySymEnabled", settings.value("stickySymEnabled", STICKY_SYM_ENABLED).toBool());
+    map.insert("lockingShiftEnabled", settings.value("lockingShiftEnabled", LOCKING_SHIFT_ENABLED).toBool());
+    map.insert("lockingCtrlEnabled", settings.value("lockingCtrlEnabled", LOCKING_CTRL_ENABLED).toBool());
+    map.insert("lockingAltEnabled", settings.value("lockingAltEnabled", LOCKING_ALT_ENABLED).toBool());
+    map.insert("lockingSymEnabled", settings.value("lockingSymEnabled", LOCKING_SYM_ENABLED).toBool());
     settings.endGroup();
 
     settings.beginGroup("layoutsettings");


### PR DESCRIPTION
move CapsLock to Sym+Caps

Each modifier can now be normal, sticky or locked. Configuration through settings application.
In normal mode, user needs to press modifier and a key together
In sticky mode, modifier is kept for one key-press and then released
In locked mode, modifier is locked down after double press

Capslock is toggled with Sym-Caps (Sym+LeftShift)

Contributes to #22
